### PR TITLE
add necessary appearance method calls for view controllers

### DIFF
--- a/Classes/ZFModalTransitionAnimator.m
+++ b/Classes/ZFModalTransitionAnimator.m
@@ -30,7 +30,7 @@
         _behindViewScale = 0.9f;
         _behindViewAlpha = 1.0f;
         _transitionDuration = 0.8f;
-        
+
         [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(orientationChanged:)
@@ -81,17 +81,17 @@
     // Grab the from and to view controllers from the context
     UIViewController *fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
     UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
-    
+
     UIView *containerView = [transitionContext containerView];
-    
+
     if (!self.isDismiss) {
-        
+
         CGRect startRect;
-        
+
         [containerView addSubview:toViewController.view];
-        
+
         toViewController.view.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-        
+
         if (self.direction == ZFModalTransitonDirectionBottom) {
             startRect = CGRectMake(0,
                                    CGRectGetHeight(containerView.frame),
@@ -108,41 +108,48 @@
                                    CGRectGetWidth(containerView.bounds),
                                    CGRectGetHeight(containerView.bounds));
         }
-        
+
         CGPoint transformedPoint = CGPointApplyAffineTransform(startRect.origin, toViewController.view.transform);
         toViewController.view.frame = CGRectMake(transformedPoint.x, transformedPoint.y, startRect.size.width, startRect.size.height);
-        
+
+        [fromViewController beginAppearanceTransition:NO animated:YES];
+		    [toViewController beginAppearanceTransition:YES animated:YES];
+
         [UIView animateWithDuration:[self transitionDuration:transitionContext]
                               delay:0
              usingSpringWithDamping:0.8
               initialSpringVelocity:0.1
                             options:UIViewAnimationOptionCurveEaseOut
                          animations:^{
-                             
+
                              fromViewController.view.transform = CGAffineTransformScale(fromViewController.view.transform, self.behindViewScale, self.behindViewScale);
                              fromViewController.view.alpha = self.behindViewAlpha;
-                             
+
                              toViewController.view.frame = CGRectMake(0,0,
                                                                       CGRectGetWidth(toViewController.view.frame),
                                                                       CGRectGetHeight(toViewController.view.frame));
-                             
-                             
+
+
                          } completion:^(BOOL finished) {
+
+                             [fromViewController endAppearanceTransition];
+			                       [toViewController endAppearanceTransition];
+
                              [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
-                             
+
                          }];
     } else {
-        
+
         [containerView bringSubviewToFront:fromViewController.view];
-        
+
         if (![self isPriorToIOS8]) {
             toViewController.view.layer.transform = CATransform3DScale(toViewController.view.layer.transform, self.behindViewScale, self.behindViewScale, 1);
         }
-        
+
         toViewController.view.alpha = self.behindViewAlpha;
-        
+
         CGRect endRect;
-        
+
         if (self.direction == ZFModalTransitonDirectionBottom) {
             endRect = CGRectMake(0,
                                  CGRectGetHeight(fromViewController.view.bounds),
@@ -159,10 +166,13 @@
                                  CGRectGetWidth(fromViewController.view.frame),
                                  CGRectGetHeight(fromViewController.view.frame));
         }
-        
+
         CGPoint transformedPoint = CGPointApplyAffineTransform(endRect.origin, fromViewController.view.transform);
         endRect = CGRectMake(transformedPoint.x, transformedPoint.y, endRect.size.width, endRect.size.height);
-        
+
+        [fromViewController beginAppearanceTransition:NO animated:YES];
+		    [toViewController beginAppearanceTransition:YES animated:YES];
+
         [UIView animateWithDuration:[self transitionDuration:transitionContext]
                               delay:0
              usingSpringWithDamping:0.8
@@ -174,8 +184,12 @@
                              toViewController.view.alpha = 1.0f;
                              fromViewController.view.frame = endRect;
                          } completion:^(BOOL finished) {
+
+                             [fromViewController endAppearanceTransition];
+			                       [toViewController endAppearanceTransition];
+
                              [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
-                             
+
                          }];
     }
 }
@@ -190,7 +204,7 @@
     // Velocity reference
     CGPoint velocity = [recognizer velocityInView:[self.modalController.view window]];
     velocity = CGPointApplyAffineTransform(velocity, CGAffineTransformInvert(recognizer.view.transform));
-    
+
     if (recognizer.state == UIGestureRecognizerStateBegan) {
         self.isInteractive = YES;
         if (self.direction == ZFModalTransitonDirectionBottom) {
@@ -200,10 +214,10 @@
         }
         [self.modalController dismissViewControllerAnimated:YES completion:nil];
     }
-    
+
     else if (recognizer.state == UIGestureRecognizerStateChanged) {
         CGFloat animationRatio = 0;
-        
+
         if (self.direction == ZFModalTransitonDirectionBottom) {
             animationRatio = (location.y - self.panLocationStart) / (CGRectGetHeight([self.modalController view].bounds));
         } else if (self.direction == ZFModalTransitonDirectionLeft) {
@@ -211,18 +225,18 @@
         } else if (self.direction == ZFModalTransitonDirectionRight) {
             animationRatio = (location.x - self.panLocationStart) / (CGRectGetWidth([self.modalController view].bounds));
         }
-        
+
         [self updateInteractiveTransition:animationRatio];
     } else if (recognizer.state == UIGestureRecognizerStateEnded) {
-        
+
         CGFloat velocityForSelectedDirection;
-        
+
         if (self.direction == ZFModalTransitonDirectionBottom) {
             velocityForSelectedDirection = velocity.y;
         } else {
             velocityForSelectedDirection = velocity.x;
         }
-        
+
         if (velocityForSelectedDirection > 100
             && (self.direction == ZFModalTransitonDirectionRight
                 || self.direction == ZFModalTransitonDirectionBottom)) {
@@ -241,19 +255,19 @@
 -(void)startInteractiveTransition:(id<UIViewControllerContextTransitioning>)transitionContext
 {
     self.transitionContext = transitionContext;
-    
+
     UIViewController *fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
     UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
-    
+
     if (![self isPriorToIOS8]) {
         toViewController.view.layer.transform = CATransform3DScale(toViewController.view.layer.transform, self.behindViewScale, self.behindViewScale, 1);
     }
-    
+
     self.tempTransform = toViewController.view.layer.transform;
-    
+
     toViewController.view.alpha = self.behindViewAlpha;
     [[transitionContext containerView] bringSubviewToFront:fromViewController.view];
-    
+
 }
 
 - (void)updateInteractiveTransition:(CGFloat)percentComplete
@@ -261,18 +275,18 @@
     if (!self.bounces && percentComplete < 0) {
         percentComplete = 0;
     }
-    
+
     id<UIViewControllerContextTransitioning> transitionContext = self.transitionContext;
-    
+
     UIViewController *fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
     UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
     CATransform3D transform = CATransform3DMakeScale(
                                                      1 + (((1 / self.behindViewScale) - 1) * percentComplete),
                                                      1 + (((1 / self.behindViewScale) - 1) * percentComplete), 1);
     toViewController.view.layer.transform = CATransform3DConcat(self.tempTransform, transform);
-    
+
     toViewController.view.alpha = self.behindViewAlpha + ((1 - self.behindViewAlpha) * percentComplete);
-    
+
     CGRect updateRect;
     if (self.direction == ZFModalTransitonDirectionBottom) {
         updateRect = CGRectMake(0,
@@ -290,7 +304,7 @@
                                 CGRectGetWidth(fromViewController.view.frame),
                                 CGRectGetHeight(fromViewController.view.frame));
     }
-    
+
     // reset to zero if x and y has unexpected value to prevent crash
     if (isnan(updateRect.origin.x) || isinf(updateRect.origin.x)) {
         updateRect.origin.x = 0;
@@ -298,22 +312,22 @@
     if (isnan(updateRect.origin.y) || isinf(updateRect.origin.y)) {
         updateRect.origin.y = 0;
     }
-    
+
     CGPoint transformedPoint = CGPointApplyAffineTransform(updateRect.origin, fromViewController.view.transform);
     updateRect = CGRectMake(transformedPoint.x, transformedPoint.y, updateRect.size.width, updateRect.size.height);
-    
+
     fromViewController.view.frame = updateRect;
 }
 
 - (void)finishInteractiveTransition
 {
     id<UIViewControllerContextTransitioning> transitionContext = self.transitionContext;
-    
+
     UIViewController *fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
     UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
-    
+
     CGRect endRect;
-    
+
     if (self.direction == ZFModalTransitonDirectionBottom) {
         endRect = CGRectMake(0,
                              CGRectGetHeight(fromViewController.view.bounds),
@@ -330,10 +344,10 @@
                              CGRectGetWidth(fromViewController.view.frame),
                              CGRectGetHeight(fromViewController.view.frame));
     }
-    
+
     CGPoint transformedPoint = CGPointApplyAffineTransform(endRect.origin, fromViewController.view.transform);
     endRect = CGRectMake(transformedPoint.x, transformedPoint.y, endRect.size.width, endRect.size.height);
-    
+
     [UIView animateWithDuration:[self transitionDuration:transitionContext]
                           delay:0
          usingSpringWithDamping:0.8
@@ -348,31 +362,31 @@
                          [transitionContext completeTransition:YES];
                          self.modalController = nil;
                      }];
-    
+
 }
 
 - (void)cancelInteractiveTransition
 {
     id<UIViewControllerContextTransitioning> transitionContext = self.transitionContext;
-    
+
     UIViewController *fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
     UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
-    
+
     [UIView animateWithDuration:0.4
                           delay:0
          usingSpringWithDamping:0.8
           initialSpringVelocity:0.1
                         options:UIViewAnimationOptionCurveEaseOut
                      animations:^{
-                         
+
                          toViewController.view.layer.transform = self.tempTransform;
                          toViewController.view.alpha = self.behindViewAlpha;
-                         
+
                          fromViewController.view.frame = CGRectMake(0,0,
                                                                     CGRectGetWidth(fromViewController.view.frame),
                                                                     CGRectGetHeight(fromViewController.view.frame));
-                         
-                         
+
+
                      } completion:^(BOOL finished) {
                          [transitionContext completeTransition:NO];
                      }];
@@ -404,7 +418,7 @@
         self.isDismiss = YES;
         return self;
     }
-    
+
     return nil;
 }
 
@@ -467,24 +481,24 @@
 - (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event
 {
     [super touchesMoved:touches withEvent:event];
-    
+
     if (!self.scrollview) {
         return;
     }
-    
+
     if (self.state == UIGestureRecognizerStateFailed) return;
     CGPoint nowPoint = [touches.anyObject locationInView:self.view];
     CGPoint prevPoint = [touches.anyObject previousLocationInView:self.view];
-    
+
     if (self.isFail) {
         if (self.isFail.boolValue) {
             self.state = UIGestureRecognizerStateFailed;
         }
         return;
     }
-    
+
     CGFloat topVerticalOffset = -self.scrollview.contentInset.top;
-    
+
     if (nowPoint.y > prevPoint.y && self.scrollview.contentOffset.y <= topVerticalOffset) {
         self.isFail = @NO;
     } else if (self.scrollview.contentOffset.y >= topVerticalOffset) {
@@ -493,7 +507,7 @@
     } else {
         self.isFail = @NO;
     }
-    
+
 }
 
 @end

--- a/Classes/ZFModalTransitionAnimator.m
+++ b/Classes/ZFModalTransitionAnimator.m
@@ -113,7 +113,6 @@
         toViewController.view.frame = CGRectMake(transformedPoint.x, transformedPoint.y, startRect.size.width, startRect.size.height);
 
         [fromViewController beginAppearanceTransition:NO animated:YES];
-		    [toViewController beginAppearanceTransition:YES animated:YES];
 
         [UIView animateWithDuration:[self transitionDuration:transitionContext]
                               delay:0
@@ -133,7 +132,6 @@
                          } completion:^(BOOL finished) {
 
                              [fromViewController endAppearanceTransition];
-			                       [toViewController endAppearanceTransition];
 
                              [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
 
@@ -169,9 +167,8 @@
 
         CGPoint transformedPoint = CGPointApplyAffineTransform(endRect.origin, fromViewController.view.transform);
         endRect = CGRectMake(transformedPoint.x, transformedPoint.y, endRect.size.width, endRect.size.height);
-
-        [fromViewController beginAppearanceTransition:NO animated:YES];
-		    [toViewController beginAppearanceTransition:YES animated:YES];
+        
+        [toViewController beginAppearanceTransition:YES animated:YES];
 
         [UIView animateWithDuration:[self transitionDuration:transitionContext]
                               delay:0
@@ -185,8 +182,7 @@
                              fromViewController.view.frame = endRect;
                          } completion:^(BOOL finished) {
 
-                             [fromViewController endAppearanceTransition];
-			                       [toViewController endAppearanceTransition];
+			     [toViewController endAppearanceTransition];
 
                              [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
 


### PR DESCRIPTION
Since a custom transition mode is used, the current implementation causes the parent view controller which is used to present the modal view controller not to receive his methods like -viewWillDisappear: etc. and -viewWillAppear: when dismissing the modal view controller.