### PR TITLE
Allow that 'draggable' can be deactivated and the animator properly disables the gesture recognizer setup

### DIFF
--- a/Classes/ZFModalTransitionAnimator.m
+++ b/Classes/ZFModalTransitionAnimator.m
@@ -49,19 +49,10 @@
 - (void)setDragable:(BOOL)dragable
 {
     _dragable = dragable;
-    if (_dragable) {
+    if (self.isDragable) {
         self.gesture = [[ZFDetectScrollViewEndGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
         self.gesture.delegate = self;
         [self.modalController.view addGestureRecognizer:self.gesture];
-    }
-    else {
-        // Animator should not be draggable.
-        // When gesture recognizer is set, then revert the previous gesture setup.
-        if (self.gesture) {
-            [self.modalController.view removeGestureRecognizer:self.gesture];
-            self.gesture.delegate = nil;
-            self.gesture = nil;
-        }
     }
 }
 

--- a/Classes/ZFModalTransitionAnimator.m
+++ b/Classes/ZFModalTransitionAnimator.m
@@ -49,10 +49,19 @@
 - (void)setDragable:(BOOL)dragable
 {
     _dragable = dragable;
-    if (self.isDragable) {
+    if (_dragable) {
         self.gesture = [[ZFDetectScrollViewEndGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
         self.gesture.delegate = self;
         [self.modalController.view addGestureRecognizer:self.gesture];
+    }
+    else {
+        // Animator should not be draggable.
+        // When gesture recognizer is set, then revert the previous gesture setup.
+        if (self.gesture) {
+            [self.modalController.view removeGestureRecognizer:self.gesture];
+            self.gesture.delegate = nil;
+            self.gesture = nil;
+        }
     }
 }
 

--- a/Classes/ZFModalTransitionAnimator.m
+++ b/Classes/ZFModalTransitionAnimator.m
@@ -50,9 +50,19 @@
 {
     _dragable = dragable;
     if (self.isDragable) {
+    if (_dragable) {
         self.gesture = [[ZFDetectScrollViewEndGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
         self.gesture.delegate = self;
         [self.modalController.view addGestureRecognizer:self.gesture];
+    }
+    else {
+        // Animator should not be draggable.
+        // When gesture recognizer is set, then revert the previous gesture setup.
+        if (self.gesture) {
+            [self.modalController.view removeGestureRecognizer:self.gesture];
+            self.gesture.delegate = nil;
+            self.gesture = nil;
+        }
     }
 }
 


### PR DESCRIPTION
Currently there's no way to reset the draggable property to NO once it has been set to YES.

This merge request tries to fix this by reverting the changes made when draggable is set to NO.