### PR TITLE
Releasing modalController when animator is done with its animation

### DIFF
--- a/Classes/ZFModalTransitionAnimator.m
+++ b/Classes/ZFModalTransitionAnimator.m
@@ -49,19 +49,10 @@
 - (void)setDragable:(BOOL)dragable
 {
     _dragable = dragable;
-    if (_dragable) {
+    if (self.isDragable) {
         self.gesture = [[ZFDetectScrollViewEndGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
         self.gesture.delegate = self;
         [self.modalController.view addGestureRecognizer:self.gesture];
-    }
-    else {
-        // Animator should not be draggable.
-        // When gesture recognizer is set, then revert the previous gesture setup.
-        if (self.gesture) {
-            [self.modalController.view removeGestureRecognizer:self.gesture];
-            self.gesture.delegate = nil;
-            self.gesture = nil;
-        }
     }
 }
 

--- a/Classes/ZFModalTransitionAnimator.m
+++ b/Classes/ZFModalTransitionAnimator.m
@@ -49,10 +49,19 @@
 - (void)setDragable:(BOOL)dragable
 {
     _dragable = dragable;
-    if (self.isDragable) {
+    if (_dragable) {
         self.gesture = [[ZFDetectScrollViewEndGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
         self.gesture.delegate = self;
         [self.modalController.view addGestureRecognizer:self.gesture];
+    }
+    else {
+        // Animator should not be draggable.
+        // When gesture recognizer is set, then revert the previous gesture setup.
+        if (self.gesture) {
+            [self.modalController.view removeGestureRecognizer:self.gesture];
+            self.gesture.delegate = nil;
+            self.gesture = nil;
+        }
     }
 }
 

--- a/Classes/ZFModalTransitionAnimator.m
+++ b/Classes/ZFModalTransitionAnimator.m
@@ -134,7 +134,7 @@
                              [fromViewController endAppearanceTransition];
 
                              [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
-
+                             self.modalController = nil;
                          }];
     } else {
 
@@ -182,10 +182,10 @@
                              fromViewController.view.frame = endRect;
                          } completion:^(BOOL finished) {
 
-			     [toViewController endAppearanceTransition];
+                             [toViewController endAppearanceTransition];
 
                              [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
-
+                             self.modalController = nil;
                          }];
     }
 }
@@ -255,7 +255,7 @@
     UIViewController *fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
     UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
 
-	[toViewController beginAppearanceTransition:YES animated:YES];
+    [toViewController beginAppearanceTransition:YES animated:YES];
 
     if (![self isPriorToIOS8]) {
         toViewController.view.layer.transform = CATransform3DScale(toViewController.view.layer.transform, self.behindViewScale, self.behindViewScale, 1);
@@ -357,12 +357,11 @@
                          fromViewController.view.frame = endRect;
                      } completion:^(BOOL finished) {
 
-						 [toViewController endAppearanceTransition];
+                         [toViewController endAppearanceTransition];
 
                          [transitionContext completeTransition:YES];
                          self.modalController = nil;
                      }];
-
 }
 
 - (void)cancelInteractiveTransition
@@ -372,7 +371,7 @@
     UIViewController *fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
     UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
 
-	[toViewController beginAppearanceTransition:NO animated:YES];
+    [toViewController beginAppearanceTransition:NO animated:YES];
 
     [UIView animateWithDuration:0.4
                           delay:0
@@ -391,9 +390,10 @@
 
                      } completion:^(BOOL finished) {
 
-						 [toViewController endAppearanceTransition];
+                         [toViewController endAppearanceTransition];
 
                          [transitionContext completeTransition:NO];
+                         self.modalController = nil;
                      }];
 }
 


### PR DESCRIPTION
Thus we can avoid having circular dependencies between the animator and
any view controller, which may cause the view controller to
not-get-deallocated.