### PR TITLE
Ensure Modal Controller gets released after transition

### DIFF
--- a/Classes/ZFModalTransitionAnimator.m
+++ b/Classes/ZFModalTransitionAnimator.m
@@ -186,11 +186,12 @@
                              toViewController.view.alpha = 1.0f;
                              fromViewController.view.frame = endRect;
                          } completion:^(BOOL finished) {
-
-			     [toViewController endAppearanceTransition];
-
+                             
+                             [toViewController endAppearanceTransition];
+                             
                              [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
-
+                             
+                             self.modalController = nil;
                          }];
     }
 }


### PR DESCRIPTION
The animator still hold a reference to the modal controller, even if the animation had been completed.
Only happened when doing non interactive transitions. 