### PR TITLE
Disable velocity horizontal direction check when gesture touch moved

### DIFF
--- a/ZFDragableModalTransition/ZFModalTransitionAnimator.m
+++ b/ZFDragableModalTransition/ZFModalTransitionAnimator.m
@@ -529,7 +529,6 @@
     }
 
     if (self.state == UIGestureRecognizerStateFailed) return;
-    CGPoint velocity = [self velocityInView:self.view];
     CGPoint nowPoint = [touches.anyObject locationInView:self.view];
     CGPoint prevPoint = [touches.anyObject previousLocationInView:self.view];
 
@@ -542,7 +541,7 @@
 
     CGFloat topVerticalOffset = -self.scrollview.contentInset.top;
 
-    if ((fabs(velocity.x) < fabs(velocity.y)) && (nowPoint.y > prevPoint.y) && (self.scrollview.contentOffset.y <= topVerticalOffset)) {
+    if ((nowPoint.y > prevPoint.y) && (self.scrollview.contentOffset.y <= topVerticalOffset)) {
         self.isFail = @NO;
     } else if (self.scrollview.contentOffset.y >= topVerticalOffset) {
         self.state = UIGestureRecognizerStateFailed;


### PR DESCRIPTION
Gesture fails even if `scrollView`  `contentOffset.y` is 0. This happens when you started more "horizontal" pan gesture than vertical. And dismiss gesture not started, even if you on top of `scrollView`. 