### PR TITLE
Fix layout error after rotation

### DIFF
--- a/ZFDragableModalTransition/ZFModalTransitionAnimator.m
+++ b/ZFDragableModalTransition/ZFModalTransitionAnimator.m
@@ -543,6 +543,13 @@
     }
 
     CGFloat topVerticalOffset = -self.scrollview.contentInset.top;
+    // @available is for Xcode 9+. Can remove this if statement if not using
+    // Xcode 9+.
+    if (@available(iOS 11, *)) {
+      if ([self.scrollview respondsToSelector:@selector(safeAreaInsets)]) {
+        topVerticalOffset -= self.scrollview.safeAreaInsets.top;
+      }
+    }
 
     if ((fabs(velocity.x) < fabs(velocity.y)) && (nowPoint.y > prevPoint.y) && (self.scrollview.contentOffset.y <= topVerticalOffset)) {
         self.isFail = @NO;

--- a/ZFDragableModalTransition/ZFModalTransitionAnimator.m
+++ b/ZFDragableModalTransition/ZFModalTransitionAnimator.m
@@ -501,7 +501,9 @@
 {
     UIViewController *backViewController = self.modalController.presentingViewController;
     backViewController.view.transform = CGAffineTransformIdentity;
-    backViewController.view.frame = self.modalController.view.bounds;
+    CGRect bounds = self.modalController.view.bounds;
+    bounds.origin = CGPointZero;
+    backViewController.view.frame = bounds;
     backViewController.view.transform = CGAffineTransformScale(backViewController.view.transform, self.behindViewScale, self.behindViewScale);
 }
 


### PR DESCRIPTION
When the modal view doesn't have a zero origin bound, after rotation, the original presenting view will be set to negative frame origin. e.g., if the bounds is -20, the backViewController's view will collide with the status bar.